### PR TITLE
fix: Updated HasValidDateRequested to handle future date.

### DIFF
--- a/src/Extensions/DateTimeOffsetExtensions.cs
+++ b/src/Extensions/DateTimeOffsetExtensions.cs
@@ -12,7 +12,12 @@ internal static class DateTimeOffsetExtensions
     /// <param name="maxAgeInSeconds">The maximum allowable age in seconds for the request to be considered valid.</param>
     /// <returns><c>true</c> if the <paramref name="dateRequested"/> is within the specified maximum age; otherwise, <c>false</c>.</returns>
     public static bool HasValidDateRequested(
-        this DateTimeOffset dateRequested, 
-        int maxAgeInSeconds
-    ) => DateTimeOffset.UtcNow.Subtract(dateRequested) < TimeSpan.FromSeconds(maxAgeInSeconds);
+      this DateTimeOffset dateRequested,
+      int maxAgeInSeconds
+    )
+    {
+        var elapsed = DateTimeOffset.UtcNow.Subtract(dateRequested);
+        return elapsed >= TimeSpan.Zero
+            && elapsed < TimeSpan.FromSeconds(maxAgeInSeconds);
+    }
 }

--- a/test/Unit/Extensions/DateTimeOffsetExtensions/Test_DateTimeOffsetExtensions_HasValidDateRequested.cs
+++ b/test/Unit/Extensions/DateTimeOffsetExtensions/Test_DateTimeOffsetExtensions_HasValidDateRequested.cs
@@ -17,4 +17,27 @@ public class Test_DateTimeOffsetExtensions_HasValidDateRequested : TestBase
     {
         Assert.That(DateTimeOffset.UtcNow.AddSeconds(-10).HasValidDateRequested(10), Is.False);
     }
+
+    // Security: future-dated timestamps must be rejected.
+    // The current implementation only checks UtcNow - dateRequested < maxAge,
+    // which produces a negative TimeSpan for future dates — always less than
+    // the positive bound — so all three tests below fail until the fix is applied.
+
+    [Test]
+    public void Test_HasValidDateRequested_FutureByOneSecond_IsFalse()
+    {
+        Assert.That(DateTimeOffset.UtcNow.AddSeconds(1).HasValidDateRequested(30), Is.False);
+    }
+
+    [Test]
+    public void Test_HasValidDateRequested_FutureByOneHour_IsFalse()
+    {
+        Assert.That(DateTimeOffset.UtcNow.AddHours(1).HasValidDateRequested(30), Is.False);
+    }
+
+    [Test]
+    public void Test_HasValidDateRequested_FutureByOneYear_IsFalse()
+    {
+        Assert.That(DateTimeOffset.UtcNow.AddYears(1).HasValidDateRequested(30), Is.False);
+    }
 }


### PR DESCRIPTION
Vuln 1: Timestamp Validation Bypass via Future-Dated Requests — DateTimeOffsetExtensions.cs:17

  - Severity: High
  - Category: authentication_bypass
  - Confidence: 9/10

  Description

  HasValidDateRequested only checks that the elapsed time since dateRequested is less than maxAgeInSeconds. It never rejects
   timestamps set in the future. When dateRequested is ahead of UtcNow, DateTimeOffset.UtcNow.Subtract(dateRequested)
  produces a negative TimeSpan. A negative value is always less than the positive maxAgeInSeconds bound, so the check
  unconditionally passes for any future timestamp — defeating the purpose of the freshness window entirely.

```
  // src/Extensions/DateTimeOffsetExtensions.cs:17
  ) => DateTimeOffset.UtcNow.Subtract(dateRequested) < TimeSpan.FromSeconds(maxAgeInSeconds);
  //   ^^ negative when dateRequested is in the future — always passes the < check
```

  The DateTimeOffsetValidator (src/Validation/Validators/DateTimeOffsetValidator.cs) only guards against MinValue and
  MaxValue; it does not impose an upper-bound constraint on future timestamps, leaving no compensating control anywhere in
  the pipeline.

  Exploit Scenario

  An attacker who holds valid HMAC credentials (public + private key) can:

  1. Pre-generate a large batch of signed requests today, each with DateRequested set one year in the future and each
  carrying a unique nonce.
  2. Submit each request at will — the timestamp check passes (negative elapsed time < positive max-age), the nonce is
  unseen, and the full HMAC signature is cryptographically valid.
  3. Because the nonce cache TTL is computed as dateRequested.AddSeconds(MaxAgeInSeconds) (NonceCache.cs:46), each nonce is
  held for ~1 year rather than maxAgeInSeconds. The replay-prevention window is effectively nullified for future-dated
  requests.
  4. If the credentials are later revoked (assuming OnValidateKeysAsync is not implemented — the default), the pre-signed
  requests remain usable until their far-future nonces expire.

  This undermines the anti-replay guarantee for any caller who controls the DateRequested header value.

  Recommendation

  Add a lower-bound guard so the timestamp must be neither in the future nor older than maxAgeInSeconds:

```
  public static bool HasValidDateRequested(
      this DateTimeOffset dateRequested,
      int maxAgeInSeconds
  )
  {
      var elapsed = DateTimeOffset.UtcNow.Subtract(dateRequested);
      return elapsed >= TimeSpan.Zero
          && elapsed < TimeSpan.FromSeconds(maxAgeInSeconds);
  }
```