### PR TITLE
Use per-TFM versions for System.Runtime.Caching

### DIFF
--- a/src/HmacManager.csproj
+++ b/src/HmacManager.csproj
@@ -36,8 +36,13 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App"/>
   </ItemGroup>
 
+  <PropertyGroup>
+    <_CachingVersion Condition="'$(TargetFramework)' == 'net8.0'">8.0.0</_CachingVersion>
+    <_CachingVersion Condition="'$(TargetFramework)' == 'net10.0'">10.0.0</_CachingVersion>
+  </PropertyGroup>
+
   <ItemGroup>
-    <PackageReference Include="System.Runtime.Caching" Version="8.0.0" />
+    <PackageReference Include="System.Runtime.Caching" Version="$(_CachingVersion)" />
   </ItemGroup>
 
   <ItemGroup> 


### PR DESCRIPTION
## Summary
- Pins `System.Runtime.Caching` to `8.0.0` for `net8.0` and `10.0.0` for `net10.0` via a conditional `_CachingVersion` property
- Ensures each target framework gets the matching out-of-band package release rather than both using the `net8.0` version

## Test plan
- [x] `dotnet build` succeeds for both TFMs
- [x] `dotnet test` passes in `test/Unit`