### PR TITLE
ci(release): add auto-merge PR and tag-on-main workflows

### DIFF
--- a/.github/scripts/extract-version.sh
+++ b/.github/scripts/extract-version.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+BRANCH="$1"
+VERSION="${BRANCH#release/v}"
+if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+  echo "Invalid version format: $BRANCH (expected release/vX.Y.Z)" >&2
+  exit 1
+fi
+echo "$VERSION"

--- a/.github/scripts/extract-version.sh
+++ b/.github/scripts/extract-version.sh
@@ -1,9 +1,13 @@
 #!/usr/bin/env bash
+
 set -euo pipefail
+
 BRANCH="$1"
 VERSION="${BRANCH#release/v}"
+
 if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
   echo "Invalid version format: $BRANCH (expected release/vX.Y.Z)" >&2
   exit 1
 fi
+
 echo "$VERSION"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,8 @@ jobs:
     name: Pack and Publish
     runs-on: ubuntu-latest
     needs: test
+    outputs:
+      version: ${{ steps.version.outputs.value }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -44,12 +46,7 @@ jobs:
       - name: Extract version from branch name
         id: version
         run: |
-          BRANCH="${GITHUB_REF#refs/heads/}"
-          VERSION="${BRANCH#release/v}"
-          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
-            echo "Invalid version format in branch name: $BRANCH (expected release/vX.Y.Z)"
-            exit 1
-          fi
+          VERSION=$(bash .github/scripts/extract-version.sh "${GITHUB_REF#refs/heads/}")
           echo "value=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Setup .NET
@@ -82,25 +79,14 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - name: Extract version from branch name
-        id: version
-        run: |
-          BRANCH="${GITHUB_REF#refs/heads/}"
-          VERSION="${BRANCH#release/v}"
-          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
-            echo "Invalid version format in branch name: $BRANCH"
-            exit 1
-          fi
-          echo "value=$VERSION" >> "$GITHUB_OUTPUT"
-
       - name: Create PR and enable auto-merge
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           PR_URL=$(gh pr create \
             --repo "$GITHUB_REPOSITORY" \
-            --title "Release v${{ steps.version.outputs.value }}" \
-            --body "Automated release PR for v${{ steps.version.outputs.value }}. Package published to NuGet successfully." \
+            --title "Release v${{ needs.publish.outputs.version }}" \
+            --body "Automated release PR for v${{ needs.publish.outputs.version }}. Package published to NuGet successfully." \
             --base main \
             --head "${{ github.ref_name }}")
           gh pr merge "$PR_URL" --merge --auto

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,3 +74,33 @@ jobs:
           --api-key ${{ secrets.NUGET_API_KEY }}
           --source https://api.nuget.org/v3/index.json
           --skip-duplicate
+
+  merge:
+    name: Open PR to Main
+    runs-on: ubuntu-latest
+    needs: publish
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Extract version from branch name
+        id: version
+        run: |
+          BRANCH="${GITHUB_REF#refs/heads/}"
+          VERSION="${BRANCH#release/v}"
+          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "Invalid version format in branch name: $BRANCH"
+            exit 1
+          fi
+          echo "value=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Create PR and enable auto-merge
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_URL=$(gh pr create \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "Release v${{ steps.version.outputs.value }}" \
+            --body "Automated release PR for v${{ steps.version.outputs.value }}. Package published to NuGet successfully." \
+            --base main \
+            --head "${{ github.ref_name }}")
+          gh pr merge "$PR_URL" --merge --auto

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,0 +1,38 @@
+name: Tag Release
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+
+jobs:
+  tag:
+    name: Create Release Tag
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/')
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Extract version from branch name
+        id: version
+        run: |
+          BRANCH="${{ github.event.pull_request.head.ref }}"
+          VERSION="${BRANCH#release/v}"
+          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "Invalid version format: $BRANCH"
+            exit 1
+          fi
+          echo "value=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Create and push tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "v${{ steps.version.outputs.value }}"
+          git push origin "v${{ steps.version.outputs.value }}"

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -22,12 +22,7 @@ jobs:
       - name: Extract version from branch name
         id: version
         run: |
-          BRANCH="${{ github.event.pull_request.head.ref }}"
-          VERSION="${BRANCH#release/v}"
-          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
-            echo "Invalid version format: $BRANCH"
-            exit 1
-          fi
+          VERSION=$(bash .github/scripts/extract-version.sh "${{ github.event.pull_request.head.ref }}")
           echo "value=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Create and push tag


### PR DESCRIPTION
## Summary

- Adds a `merge` job to `release.yml` that runs after a successful publish, opens a PR from the release branch into `main`, and enables auto-merge
- Adds a new `tag.yml` workflow that fires when a `release/**` PR is merged into `main`, creating the `vX.Y.Z` git tag on the resulting main commit

## How it works

```
push release/vX.Y.Z
  → test → publish → open PR to main (auto-merge enabled)
    → pr.yml CI passes → PR auto-merges
      → tag.yml fires → vX.Y.Z tag created on main
```

## Prerequisites

Enable **Allow auto-merge** in each repo: Settings → General → Pull Requests.

## Test plan
- [ ] Enable "Allow auto-merge" in repo settings
- [ ] Push a `release/v0.0.0-test` branch and confirm the `merge` job opens a PR targeting `main`
- [ ] Confirm auto-merge banner appears on the PR
- [ ] After PR merges, confirm `tag.yml` creates the `v0.0.0-test` tag on `main`