### PR TITLE
docs: center logo art and remove Further Reading

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ _Secure HMAC request authentication for ASP.NET Core — as a NuGet library, or 
 - [Documentation](./src/README.md)
 - [Client Library](./client/)
 - [Resources](#resources)
-- [Further Reading](#further-reading)
 
 ## Summary
 
@@ -68,8 +67,3 @@ See the [Kubernetes setup guide](kubernetes/service/README.md) for the full walk
 
 - [Documentation](src/README.md)
 - [Samples](samples/README.md)
-
-## Further Reading
-
-- [Hmac](https://en.wikipedia.org/wiki/Hmac)
-- [Sign an Http Request](https://learn.microsoft.com/en-us/azure/communication-services/tutorials/Hmac-header-tutorial?pivots=programming-language-csharp)

--- a/assets/logo.svg
+++ b/assets/logo.svg
@@ -1,16 +1,16 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="470" height="220" viewBox="0 0 470 220" role="img" aria-label="HMAC MANAGER">
-  <text xml:space="preserve" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, 'Courier New', monospace" font-size="14" fill="#58a6ff">
-    <tspan x="8" y="20">╔═════════════════════════════════════════════════╗</tspan>
-    <tspan x="8" y="37">║     __  ____  ______   ______                   ║</tspan>
-    <tspan x="8" y="54">║    / / / /  |/  /   | / ____/                   ║</tspan>
-    <tspan x="8" y="71">║   / /_/ / /|_/ / /| |/ /                        ║</tspan>
-    <tspan x="8" y="88">║  / __  / /  / / ___ / /___                      ║</tspan>
-    <tspan x="8" y="105">║ /_/ /_/_/  /_/_/  |_\____/                      ║</tspan>
-    <tspan x="8" y="122">║     __  ______    _   _____   ________________  ║</tspan>
-    <tspan x="8" y="139">║    /  |/  /   |  / | / /   | / ____/ ____/ __ \ ║</tspan>
-    <tspan x="8" y="156">║   / /|_/ / /| | /  |/ / /| |/ / __/ __/ / /_/ / ║</tspan>
-    <tspan x="8" y="173">║  / /  / / ___ |/ /|  / ___ / /_/ / /___/ _, _/  ║</tspan>
-    <tspan x="8" y="190">║ /_/  /_/_/  |_/_/ |_/_/  |_\____/_____/_/ |_|   ║</tspan>
-    <tspan x="8" y="207">╚═════════════════════════════════════════════════╝</tspan>
+  <text xml:space="preserve" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, 'Courier New', monospace" font-size="14" fill="#58a6ff">
+    <tspan x="235" y="20">╔═════════════════════════════════════════════════╗</tspan>
+    <tspan x="235" y="37">║     __  ____  ______   ______                   ║</tspan>
+    <tspan x="235" y="54">║    / / / /  |/  /   | / ____/                   ║</tspan>
+    <tspan x="235" y="71">║   / /_/ / /|_/ / /| |/ /                        ║</tspan>
+    <tspan x="235" y="88">║  / __  / /  / / ___ / /___                      ║</tspan>
+    <tspan x="235" y="105">║ /_/ /_/_/  /_/_/  |_\____/                      ║</tspan>
+    <tspan x="235" y="122">║     __  ______    _   _____   ________________  ║</tspan>
+    <tspan x="235" y="139">║    /  |/  /   |  / | / /   | / ____/ ____/ __ \ ║</tspan>
+    <tspan x="235" y="156">║   / /|_/ / /| | /  |/ / /| |/ / __/ __/ / /_/ / ║</tspan>
+    <tspan x="235" y="173">║  / /  / / ___ |/ /|  / ___ / /_/ / /___/ _, _/  ║</tspan>
+    <tspan x="235" y="190">║ /_/  /_/_/  |_/_/ |_/_/  |_\____/_____/_/ |_|   ║</tspan>
+    <tspan x="235" y="207">╚═════════════════════════════════════════════════╝</tspan>
   </text>
 </svg>


### PR DESCRIPTION
- **Logo centering**: the ASCII art was left-aligned inside the SVG viewBox (`x=8` with empty space on the right), so the centered `<img>` looked shifted left. Switched to `text-anchor=\"middle\"` so the art is centered within the viewBox and renders truly centered in the README.
- **Remove Further Reading**: dropped the section and its TOC entry.