### PR TITLE
Update Artifact Hub repository ID and remove Further Reading section

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ _Secure HMAC request authentication for ASP.NET Core — as a NuGet library, or 
 - [Documentation](./src/README.md)
 - [Client Library](./client/)
 - [Resources](#resources)
-- [Further Reading](#further-reading)
 
 ## Summary
 
@@ -68,8 +67,3 @@ See the [Kubernetes setup guide](kubernetes/service/README.md) for the full walk
 
 - [Documentation](src/README.md)
 - [Samples](samples/README.md)
-
-## Further Reading
-
-- [Hmac](https://en.wikipedia.org/wiki/Hmac)
-- [Sign an Http Request](https://learn.microsoft.com/en-us/azure/communication-services/tutorials/Hmac-header-tutorial?pivots=programming-language-csharp)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 <img src="assets/logo.svg" alt="HMAC MANAGER" width="470">
 
-[![NuGet Version](https://img.shields.io/nuget/v/HmacManager.svg)](https://www.nuget.org/packages/HmacManager/) [![NuGet Downloads](https://img.shields.io/nuget/dt/HmacManager.svg)](https://www.nuget.org/packages/HmacManager/) [![npm Version](https://img.shields.io/npm/v/hmac-manager?logo=npm&label=npm)](https://www.npmjs.com/package/hmac-manager) [![Docker Image Version](https://img.shields.io/docker/v/zills/hmac-manager?logo=docker&label=docker)](https://hub.docker.com/r/zills/hmac-manager) [![Docker Pulls](https://img.shields.io/docker/pulls/zills/hmac-manager?logo=docker)](https://hub.docker.com/r/zills/hmac-manager) [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/hmac-manager)](https://artifacthub.io/packages/search?repo=hmac-manager) [![.NET](https://github.com/jzills/HmacManager/actions/workflows/pr.yml/badge.svg)](https://github.com/jzills/HmacManager/actions/workflows/pr.yml) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![NuGet Version](https://img.shields.io/nuget/v/HmacManager.svg)](https://www.nuget.org/packages/HmacManager/) [![NuGet Downloads](https://img.shields.io/nuget/dt/HmacManager.svg)](https://www.nuget.org/packages/HmacManager/) [![npm Version](https://img.shields.io/npm/v/hmac-manager?logo=npm&label=npm)](https://www.npmjs.com/package/hmac-manager) [![Docker Image Version](https://img.shields.io/docker/v/zills/hmac-manager?logo=docker&label=docker)](https://hub.docker.com/r/zills/hmac-manager) [![Docker Pulls](https://img.shields.io/docker/pulls/zills/hmac-manager?logo=docker)](https://hub.docker.com/r/zills/hmac-manager) [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/zills)](https://artifacthub.io/packages/search?repo=zills) [![.NET](https://github.com/jzills/HmacManager/actions/workflows/pr.yml/badge.svg)](https://github.com/jzills/HmacManager/actions/workflows/pr.yml) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 _Secure HMAC request authentication for ASP.NET Core — as a NuGet library, or as a containerized Istio ext-authz service for Kubernetes._
 
@@ -50,9 +50,9 @@ docker pull zills/hmac-manager:latest
 **Helm chart** — install from the GitHub Pages HTTP repo:
 
 ```bash
-helm repo add hmac-manager https://jzills.github.io/HmacManager
+helm repo add zills https://jzills.github.io/HmacManager
 helm repo update
-helm install hmac-manager hmac-manager/hmac-manager
+helm install hmac-manager zills/hmac-manager
 ```
 
 or pull it from GHCR as an OCI artifact:

--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -1,4 +1,4 @@
-repositoryID: "fe19f84b-f3d2-43e7-aa02-5ba3ff852916"
+repositoryID: "9e68637b-484e-464f-b2c8-e0db94554403"
 owners:
   - name: Joshua Zillwood
     email: joshua.zillwood@gmail.com

--- a/pages/index.html
+++ b/pages/index.html
@@ -51,9 +51,9 @@
     <p class="tag">Istio ambient-mode ext-authz service for HMAC request authentication.</p>
 
     <h2>Install from this repository (HTTP)</h2>
-<pre class="cmd">helm repo add hmac-manager https://jzills.github.io/HmacManager
+<pre class="cmd">helm repo add zills https://jzills.github.io/HmacManager
 helm repo update
-helm install hmac-manager hmac-manager/hmac-manager</pre>
+helm install hmac-manager zills/hmac-manager</pre>
 
     <h2>Or pull the chart from GHCR (OCI)</h2>
 <pre class="cmd">helm install hmac-manager oci://ghcr.io/jzills/charts/hmac-manager --version 0.0.1</pre>
@@ -63,7 +63,7 @@ helm install hmac-manager hmac-manager/hmac-manager</pre>
 
     <ul class="links">
       <li><a href="https://github.com/jzills/HmacManager">GitHub</a></li>
-      <li><a href="https://artifacthub.io/packages/search?repo=hmac-manager">Artifact Hub</a></li>
+      <li><a href="https://artifacthub.io/packages/search?repo=zills">Artifact Hub</a></li>
       <li><a href="https://hub.docker.com/r/zills/hmac-manager">Docker Hub</a></li>
       <li><a href="https://www.nuget.org/packages/HmacManager">NuGet</a></li>
       <li><a href="https://github.com/jzills/HmacManager/blob/main/kubernetes/service/README.md">Setup guide</a></li>


### PR DESCRIPTION
## Summary

- Updates `artifacthub-repo.yml` with the new Artifact Hub repository ID to point to the renamed repo
- Removes the "Further Reading" section and its table-of-contents entry from the root README

## Test plan

- [ ] Verify `artifacthub-repo.yml` contains the correct `repositoryID`
- [ ] Verify the "Further Reading" section and TOC link are gone from `README.md`