### PR TITLE
Update stale repo links to new lowercase-hyphenated repo name

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 <img src="assets/logo.svg" alt="HMAC MANAGER" width="470">
 
-[![NuGet Version](https://img.shields.io/nuget/v/HmacManager.svg)](https://www.nuget.org/packages/HmacManager/) [![NuGet Downloads](https://img.shields.io/nuget/dt/HmacManager.svg)](https://www.nuget.org/packages/HmacManager/) [![npm Version](https://img.shields.io/npm/v/hmac-manager?logo=npm&label=npm)](https://www.npmjs.com/package/hmac-manager) [![Docker Image Version](https://img.shields.io/docker/v/zills/hmac-manager?logo=docker&label=docker)](https://hub.docker.com/r/zills/hmac-manager) [![Docker Pulls](https://img.shields.io/docker/pulls/zills/hmac-manager?logo=docker)](https://hub.docker.com/r/zills/hmac-manager) [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/zills)](https://artifacthub.io/packages/search?repo=zills) [![.NET](https://github.com/jzills/HmacManager/actions/workflows/pr.yml/badge.svg)](https://github.com/jzills/HmacManager/actions/workflows/pr.yml) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![NuGet Version](https://img.shields.io/nuget/v/HmacManager.svg)](https://www.nuget.org/packages/HmacManager/) [![NuGet Downloads](https://img.shields.io/nuget/dt/HmacManager.svg)](https://www.nuget.org/packages/HmacManager/) [![npm Version](https://img.shields.io/npm/v/hmac-manager?logo=npm&label=npm)](https://www.npmjs.com/package/hmac-manager) [![Docker Image Version](https://img.shields.io/docker/v/zills/hmac-manager?logo=docker&label=docker)](https://hub.docker.com/r/zills/hmac-manager) [![Docker Pulls](https://img.shields.io/docker/pulls/zills/hmac-manager?logo=docker)](https://hub.docker.com/r/zills/hmac-manager) [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/zills)](https://artifacthub.io/packages/search?repo=zills) [![.NET](https://github.com/jzills/hmac-manager/actions/workflows/pr.yml/badge.svg)](https://github.com/jzills/hmac-manager/actions/workflows/pr.yml) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 _Secure HMAC request authentication for ASP.NET Core — as a NuGet library, or as a containerized Istio ext-authz service for Kubernetes._
 
@@ -42,7 +42,7 @@ Add secure HMAC request authentication to ASP.NET Core APIs with lightweight, co
 Beyond the .NET library, HmacManager ships a containerized verification service and a Helm chart for enforcing HMAC authentication at the mesh edge. The service runs as an [Envoy ext-authz](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/http/ext_authz/v3/ext_authz.proto) HTTP server: an Istio ingress gateway or ambient waypoint calls it before forwarding a request, and anything without a valid HMAC signature is rejected with `403`. Redis is bundled for replay protection — no external dependencies to provision.
 
 ```bash
-helm repo add zills https://jzills.github.io/HmacManager
+helm repo add zills https://jzills.github.io/hmac-manager
 helm repo update
 helm install hmac-manager zills/hmac-manager \
   --namespace hmac-system --create-namespace \

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -127,7 +127,7 @@ The chart is published two ways from the same `chart/vX.Y.Z` tag:
 Install via the HTTP repo:
 
 ```bash
-helm repo add zills https://jzills.github.io/HmacManager
+helm repo add zills https://jzills.github.io/hmac-manager
 helm repo update
 helm install hmac-manager zills/hmac-manager --version 1.5.0
 ```
@@ -142,7 +142,7 @@ helm install hmac-manager oci://ghcr.io/jzills/charts/hmac-manager --version 1.5
 > GitHub Pages for it (Settings → Pages → Branch: `gh-pages`, folder `/`). The
 > `pages` job in `chart-release.yml` then publishes `index.yaml`, the packaged
 > chart, and `artifacthub-repo.yml` to the Pages root on each chart release.
-> Point Artifact Hub at `https://jzills.github.io/HmacManager`; because the repo
+> Point Artifact Hub at `https://jzills.github.io/hmac-manager`; because the repo
 > metadata file is served at the root, the Verified Publisher badge works with no
 > extra OCI metadata push.
 

--- a/client/lib/README.md
+++ b/client/lib/README.md
@@ -1,7 +1,7 @@
 
 ## Summary
 
-JavaScript and TypeScript clients for ASP.NET Core [HmacManager](https://github.com/jzills/HmacManager/blob/main/README.md).
+JavaScript and TypeScript clients for ASP.NET Core [HmacManager](https://github.com/jzills/hmac-manager/blob/main/README.md).
 
 ## Installation
 
@@ -9,4 +9,4 @@ JavaScript and TypeScript clients for ASP.NET Core [HmacManager](https://github.
 
 ## Usage
 
-Documentation can be found [here](https://github.com/jzills/HmacManager/blob/main/client/lib/hmac_manager/README.md).
+Documentation can be found [here](https://github.com/jzills/hmac-manager/blob/main/client/lib/hmac_manager/README.md).

--- a/client/lib/package.json
+++ b/client/lib/package.json
@@ -10,7 +10,7 @@
     "type": "module",
     "repository": {
         "type": "git",
-        "url": "https://github.com/jzills/HmacManager.git"
+        "url": "https://github.com/jzills/hmac-manager.git"
     },
     "main": "./dist/index.cjs",
     "module": "./dist/index.js",

--- a/kubernetes/chart/README.md
+++ b/kubernetes/chart/README.md
@@ -22,7 +22,7 @@ Client → Istio waypoint / ingress gateway
 ## Install
 
 ```bash
-helm repo add zills https://jzills.github.io/HmacManager
+helm repo add zills https://jzills.github.io/hmac-manager
 helm repo update
 ```
 
@@ -190,4 +190,4 @@ Returns the HMAC headers to attach to your request. Never use `Development` in a
 
 ## Source
 
-[github.com/jzills/HmacManager](https://github.com/jzills/HmacManager)
+[github.com/jzills/hmac-manager](https://github.com/jzills/hmac-manager)

--- a/kubernetes/chart/artifacthub-pkg.yml
+++ b/kubernetes/chart/artifacthub-pkg.yml
@@ -6,7 +6,7 @@ description: Istio ext-authz HTTP server for HMAC request authentication
 logoURL: ""
 digest: ""
 license: MIT
-homeURL: https://github.com/jzills/HmacManager
+homeURL: https://github.com/jzills/hmac-manager
 keywords:
   - hmac
   - authentication
@@ -15,7 +15,7 @@ keywords:
   - security
 links:
   - name: Source
-    url: https://github.com/jzills/HmacManager
+    url: https://github.com/jzills/hmac-manager
   - name: NuGet
     url: https://www.nuget.org/packages/HmacManager
 maintainers:

--- a/kubernetes/pages/index.html
+++ b/kubernetes/pages/index.html
@@ -52,7 +52,7 @@
     <p class="tag">Istio ambient-mode ext-authz service for HMAC request authentication.</p>
 
     <h2>Install from this repository (HTTP)</h2>
-<pre class="cmd">helm repo add zills https://jzills.github.io/HmacManager
+<pre class="cmd">helm repo add zills https://jzills.github.io/hmac-manager
 helm repo update
 helm install hmac-manager zills/hmac-manager \
   --namespace hmac-system --create-namespace \
@@ -74,11 +74,11 @@ helm install hmac-manager zills/hmac-manager \
 <pre class="cmd">docker pull zills/hmac-manager:latest</pre>
 
     <ul class="links">
-      <li><a href="https://github.com/jzills/HmacManager">GitHub</a></li>
+      <li><a href="https://github.com/jzills/hmac-manager">GitHub</a></li>
       <li><a href="https://artifacthub.io/packages/search?repo=zills">Artifact Hub</a></li>
       <li><a href="https://hub.docker.com/r/zills/hmac-manager">Docker Hub</a></li>
       <li><a href="https://www.nuget.org/packages/HmacManager">NuGet</a></li>
-      <li><a href="https://github.com/jzills/HmacManager/blob/main/kubernetes/service/README.md">Setup guide</a></li>
+      <li><a href="https://github.com/jzills/hmac-manager/blob/main/kubernetes/service/README.md">Setup guide</a></li>
     </ul>
 
     <footer>This page is the Helm chart index host — <a href="index.yaml">index.yaml</a>.</footer>

--- a/kubernetes/service/README.md
+++ b/kubernetes/service/README.md
@@ -15,10 +15,10 @@ Client → Istio waypoint / ingress gateway
 
 ## Deploy with Helm
 
-The recommended way to run this image is via the [hmac-manager Helm chart](https://github.com/jzills/HmacManager/tree/main/kubernetes/chart), which bundles Redis for replay protection and abstracts all configuration:
+The recommended way to run this image is via the [hmac-manager Helm chart](https://github.com/jzills/hmac-manager/tree/main/kubernetes/chart), which bundles Redis for replay protection and abstracts all configuration:
 
 ```bash
-helm repo add zills https://jzills.github.io/HmacManager
+helm repo add zills https://jzills.github.io/hmac-manager
 helm repo update
 
 helm install hmac-manager zills/hmac-manager \
@@ -92,4 +92,4 @@ Use the [HmacManager NuGet package](https://www.nuget.org/packages/HmacManager) 
 
 ## Source
 
-[github.com/jzills/HmacManager](https://github.com/jzills/HmacManager)
+[github.com/jzills/hmac-manager](https://github.com/jzills/hmac-manager)

--- a/samples/README.md
+++ b/samples/README.md
@@ -1,7 +1,7 @@
 
 # HmacManager Samples
 
-[![NuGet Version](https://img.shields.io/nuget/v/HmacManager.svg)](https://www.nuget.org/packages/HmacManager/) [![NuGet Downloads](https://img.shields.io/nuget/dt/HmacManager.svg)](https://www.nuget.org/packages/HmacManager/) [![.NET](https://github.com/jzills/HmacManager/actions/workflows/pr.yml/badge.svg)](https://github.com/jzills/HmacManager/actions/workflows/pr.yml)
+[![NuGet Version](https://img.shields.io/nuget/v/HmacManager.svg)](https://www.nuget.org/packages/HmacManager/) [![NuGet Downloads](https://img.shields.io/nuget/dt/HmacManager.svg)](https://www.nuget.org/packages/HmacManager/) [![.NET](https://github.com/jzills/hmac-manager/actions/workflows/pr.yml/badge.svg)](https://github.com/jzills/hmac-manager/actions/workflows/pr.yml)
 
 - [Simple Authentication](./WebToApiAuthentication/README.md)
 - [Registering HmacManager with Json](./WebToApiAuthenticationWithJsonConfiguration/README.md)

--- a/src/HmacManager.csproj
+++ b/src/HmacManager.csproj
@@ -16,8 +16,8 @@
     <Company></Company>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageProjectUrl>https://github.com/jzills/HmacManager</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/jzills/HmacManager.git</RepositoryUrl> 
+    <PackageProjectUrl>https://github.com/jzills/hmac-manager</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/jzills/hmac-manager.git</RepositoryUrl> 
     <RepositoryType>git</RepositoryType> 
     <PackageIcon>Icon.jpg</PackageIcon>
     <PackageTags>hmac;authentication</PackageTags>

--- a/src/Mvc/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Mvc/Extensions/IServiceCollectionExtensions.cs
@@ -13,7 +13,7 @@ public static class IServiceCollectionExtensions
     /// Registers the necessary dependencies to use <see cref="HmacManager.Components.IHmacManagerFactory"/>
     /// in the dependency injection container with the configured <see cref="HmacManagerOptions"/>.
     ///     <para>
-    ///         See <see href="https://github.com/jzills/HmacManager/tree/main/samples/">here</see> for examples.
+    ///         See <see href="https://github.com/jzills/hmac-manager/tree/main/samples/">here</see> for examples.
     ///     </para>
     /// </summary>
     /// <param name="services">The <see cref="IServiceCollection"/>.</param>
@@ -34,7 +34,7 @@ public static class IServiceCollectionExtensions
     /// Registers the necessary dependencies to use <see cref="HmacManager.Components.IHmacManagerFactory"/>
     /// in the dependency injection container with the corresponding <see cref="IConfiguration"/> settings.
     ///     <para>
-    ///         See <see href="https://github.com/jzills/HmacManager/tree/main/samples/">here</see> for examples.
+    ///         See <see href="https://github.com/jzills/hmac-manager/tree/main/samples/">here</see> for examples.
     ///     </para>
     /// </summary>
     /// <param name="services">The <see cref="IServiceCollection"/>.</param>

--- a/src/README.md
+++ b/src/README.md
@@ -1,7 +1,7 @@
 
 # HmacManager
 
-[![NuGet Version](https://img.shields.io/nuget/v/HmacManager.svg)](https://www.nuget.org/packages/HmacManager/) [![NuGet Downloads](https://img.shields.io/nuget/dt/HmacManager.svg)](https://www.nuget.org/packages/HmacManager/) [![.NET](https://github.com/jzills/HmacManager/actions/workflows/pr.yml/badge.svg)](https://github.com/jzills/HmacManager/actions/workflows/pr.yml)
+[![NuGet Version](https://img.shields.io/nuget/v/HmacManager.svg)](https://www.nuget.org/packages/HmacManager/) [![NuGet Downloads](https://img.shields.io/nuget/dt/HmacManager.svg)](https://www.nuget.org/packages/HmacManager/) [![.NET](https://github.com/jzills/hmac-manager/actions/workflows/pr.yml/badge.svg)](https://github.com/jzills/hmac-manager/actions/workflows/pr.yml)
 
 - [Quickstart](#quickstart)
     * [Register without built-in authentication flow](#register-without-built-in-authentication-flow)


### PR DESCRIPTION
## Summary
- The GitHub repo was renamed from `HmacManager` to `hmac-manager`.
- Updates hardcoded `github.com/jzills/HmacManager` and `jzills.github.io/HmacManager` URLs across README/RELEASING docs, the Helm chart README/artifacthub-pkg.yml, the GitHub Pages install page, `client/lib/package.json` repository URL, `src/HmacManager.csproj` PackageProjectUrl/RepositoryUrl, and XML doc comment links in `IServiceCollectionExtensions.cs`.
- Left the NuGet `PackageId` (`HmacManager`), NuGet badge/package URLs, npm package name (`hmac-manager`), and Docker image name (`zills/hmac-manager`) untouched, since those are code-level identifiers, not GitHub repo references.

## Test plan
- [x] `git grep` confirmed no remaining `github.com/jzills/HmacManager` or `jzills.github.io/HmacManager` references.
- [x] Verified no NuGet PackageId/RepositoryType/package names were altered.