### PR TITLE
fix(ci): repair release tagging automation for multi-artifact Gitflow

### DIFF
--- a/.github/scripts/extract-version.sh
+++ b/.github/scripts/extract-version.sh
@@ -3,11 +3,29 @@
 set -euo pipefail
 
 BRANCH="$1"
-VERSION="${BRANCH#release/v}"
+
+case "$BRANCH" in
+  release/service/v*)
+    PREFIX="service"
+    VERSION="${BRANCH#release/service/v}"
+    ;;
+  release/chart/v*)
+    PREFIX="chart"
+    VERSION="${BRANCH#release/chart/v}"
+    ;;
+  release/v*)
+    PREFIX="nuget"
+    VERSION="${BRANCH#release/v}"
+    ;;
+  *)
+    echo "Unrecognized release branch: $BRANCH (expected release/vX.Y.Z, release/service/vX.Y.Z, or release/chart/vX.Y.Z)" >&2
+    exit 1
+    ;;
+esac
 
 if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
-  echo "Invalid version format: $BRANCH (expected release/vX.Y.Z)" >&2
+  echo "Invalid version format: $BRANCH" >&2
   exit 1
 fi
 
-echo "$VERSION"
+echo "$PREFIX/v$VERSION"

--- a/.github/workflows/service-release.yml
+++ b/.github/workflows/service-release.yml
@@ -72,12 +72,8 @@ jobs:
             ${{ secrets.DOCKERHUB_USERNAME }}/hmac-manager:${{ steps.version.outputs.value }}
             ${{ secrets.DOCKERHUB_USERNAME }}/hmac-manager:latest
 
-      # Docker Hub's API rejects repository metadata edits from scoped access
-      # tokens (403), even though the same token can push images fine — this
-      # is cosmetic, so don't fail the release over it.
       - name: Update Docker Hub description
         uses: peter-evans/dockerhub-description@v4
-        continue-on-error: true
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/service-release.yml
+++ b/.github/workflows/service-release.yml
@@ -72,8 +72,12 @@ jobs:
             ${{ secrets.DOCKERHUB_USERNAME }}/hmac-manager:${{ steps.version.outputs.value }}
             ${{ secrets.DOCKERHUB_USERNAME }}/hmac-manager:latest
 
+      # Docker Hub's API rejects repository metadata edits from scoped access
+      # tokens (403), even though the same token can push images fine — this
+      # is cosmetic, so don't fail the release over it.
       - name: Update Docker Hub description
         uses: peter-evans/dockerhub-description@v4
+        continue-on-error: true
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -45,7 +45,12 @@ jobs:
 
       - name: Check release branch has changes to merge back
         run: |
-          git fetch origin develop "${{ github.event.pull_request.head.ref }}"
+          # checkout on a pull_request event leaves a narrow fetch refspec, so
+          # fetch into explicit remote-tracking refs — a bare `git fetch origin <branch>`
+          # only writes FETCH_HEAD, leaving origin/develop et al. unresolvable below.
+          git fetch origin \
+            "develop:refs/remotes/origin/develop" \
+            "${{ github.event.pull_request.head.ref }}:refs/remotes/origin/${{ github.event.pull_request.head.ref }}"
           if git diff --quiet "origin/develop...origin/${{ github.event.pull_request.head.ref }}"; then
             echo "::error::Release branch '${{ github.event.pull_request.head.ref }}' has no changes vs develop." \
               "Did you forget to bump the version (HmacManager.csproj, the service project, or Chart.yaml) before merging?" \

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -19,18 +19,18 @@ jobs:
           ref: main
           fetch-depth: 0
 
-      - name: Extract version from branch name
+      - name: Extract tag from branch name
         id: version
         run: |
-          VERSION=$(bash .github/scripts/extract-version.sh "${{ github.event.pull_request.head.ref }}")
-          echo "value=$VERSION" >> "$GITHUB_OUTPUT"
+          TAG=$(bash .github/scripts/extract-version.sh "${{ github.event.pull_request.head.ref }}")
+          echo "value=$TAG" >> "$GITHUB_OUTPUT"
 
       - name: Create and push tag
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag "v${{ steps.version.outputs.value }}"
-          git push origin "v${{ steps.version.outputs.value }}"
+          git tag "${{ steps.version.outputs.value }}"
+          git push origin "${{ steps.version.outputs.value }}"
 
   merge-back:
     name: Merge Release Back to Develop
@@ -39,6 +39,20 @@ jobs:
     permissions:
       pull-requests: write
     steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Check release branch has changes to merge back
+        run: |
+          git fetch origin develop "${{ github.event.pull_request.head.ref }}"
+          if git diff --quiet "origin/develop...origin/${{ github.event.pull_request.head.ref }}"; then
+            echo "::error::Release branch '${{ github.event.pull_request.head.ref }}' has no changes vs develop." \
+              "Did you forget to bump the version (HmacManager.csproj, the service project, or Chart.yaml) before merging?" \
+              "Nothing to merge back into develop — fix the version bump and push a follow-up commit or handle the merge manually."
+            exit 1
+          fi
+
       - name: Open PR to merge release branch back into develop
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,6 +4,8 @@ This project has three independently versioned artifacts, each with its own rele
 
 Tagging is automated by `.github/workflows/tag.yml`: it fires whenever a PR whose head branch starts with `release/` is merged into `main`, extracts the artifact and version from the branch name (`.github/scripts/extract-version.sh`), and pushes the matching prefixed tag. Merging into `main` with a direct `git push` (bypassing a PR) will **not** trigger a release — the merge must go through a PR for `tag.yml` to fire.
 
+> **Prerequisite for `gh pr merge --auto`:** the examples below queue the merge with `--auto`, which requires the repository's **Allow auto-merge** setting to be enabled (Settings → General → Pull Requests) and at least one required status check on `main`. If auto-merge is disabled, `gh pr merge --auto` errors out — drop `--auto` and run `gh pr merge --merge` to merge immediately once checks are green.
+
 ## Artifacts and Tag Prefixes
 
 | Artifact | Release branch | Tag format | Trigger |

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,16 +1,21 @@
 # Releasing
 
-This project has three independently versioned artifacts, each with its own release pipeline. All releases follow Gitflow: work lands on `develop` via feature branches, gets stabilized on a release branch, merges into `main`, and is tagged at that merge commit.
+This project has three independently versioned artifacts, each with its own release pipeline. All releases follow Gitflow: work lands on `develop` via feature branches, gets stabilized on a release branch, merges into `main` **via a pull request**, and is tagged automatically at that merge commit.
+
+Tagging is automated by `.github/workflows/tag.yml`: it fires whenever a PR whose head branch starts with `release/` is merged into `main`, extracts the artifact and version from the branch name (`.github/scripts/extract-version.sh`), and pushes the matching prefixed tag. Merging into `main` with a direct `git push` (bypassing a PR) will **not** trigger a release — the merge must go through a PR for `tag.yml` to fire.
 
 ## Artifacts and Tag Prefixes
 
-| Artifact | Tag format | Trigger |
-|---|---|---|
-| NuGet package | `nuget/vX.Y.Z` | `.github/workflows/release.yml` |
-| Docker image (ext-authz service) | `service/vX.Y.Z` | `.github/workflows/service-release.yml` |
-| Helm chart | `chart/vX.Y.Z` | `.github/workflows/chart-release.yml` |
+| Artifact | Release branch | Tag format | Trigger |
+|---|---|---|---|
+| NuGet package | `release/vX.Y.Z` | `nuget/vX.Y.Z` | `.github/workflows/release.yml` |
+| Docker image (ext-authz service) | `release/service/vX.Y.Z` | `service/vX.Y.Z` | `.github/workflows/service-release.yml` |
+| Helm chart | `release/chart/vX.Y.Z` | `chart/vX.Y.Z` | `.github/workflows/chart-release.yml` |
 
-Versions are extracted from the tag at publish time — no source files need manual version bumps except `Chart.yaml`'s `appVersion` field (see [Helm chart release](#helm-chart) below).
+The published version always comes from the tag, not from any source file. Even so, each release branch must bump its own version file (`HmacManager.csproj`'s `<Version>` for NuGet, `HmacManager.Kubernetes.csproj`'s `<Version>` for the service, `Chart.yaml`'s `version` for the chart — see [Helm chart release](#helm-chart) for `appVersion`) so that:
+
+- local/manual builds report the right version, and
+- the release branch has a real commit to bring back into `develop`. If a release branch has no changes vs `develop` at merge time, `tag.yml`'s `merge-back` job fails loudly with an error telling you to bump the version — it does not silently skip.
 
 ---
 
@@ -23,20 +28,19 @@ Covers changes to the core library under `src/`.
 git checkout develop && git pull origin develop
 git checkout -b release/v2.7.0
 
-# 2. Stabilize (bug fixes, changelog, etc.), then merge into main
-git checkout main && git pull origin main
-git merge --no-ff release/v2.7.0
-git push origin main
+# 2. Bump the version and stabilize (bug fixes, changelog, etc.)
+#    Edit src/HmacManager.csproj: <Version>2.7.0</Version>
+git commit -am "chore: bump version to 2.7.0"
+git push origin release/v2.7.0
 
-# 3. Tag and publish via GitHub Release
-gh release create nuget/v2.7.0 --target main --generate-notes
+# 3. Open a PR release/v2.7.0 -> main and merge it once checks pass.
+#    Merging the PR automatically:
+#      - tags main as nuget/v2.7.0 (triggers release.yml: test, pack, publish)
+#      - opens and auto-merges a PR to back-merge release/v2.7.0 into develop
+gh pr create --base main --head release/v2.7.0 --title "release: nuget v2.7.0" --fill
+gh pr merge --merge --auto
 
-# 4. Back-merge into develop
-git checkout develop
-git merge --no-ff main
-git push origin develop
-
-# 5. Delete the release branch
+# 4. Once the back-merge PR has merged, delete the release branch
 git push origin --delete release/v2.7.0
 git branch -d release/v2.7.0
 ```
@@ -54,20 +58,19 @@ Covers changes to `kubernetes/service/`.
 git checkout develop && git pull origin develop
 git checkout -b release/service/v1.2.0
 
-# 2. Stabilize, then merge into main
-git checkout main && git pull origin main
-git merge --no-ff release/service/v1.2.0
-git push origin main
+# 2. Bump the version and stabilize
+#    Edit kubernetes/service/HmacManager.Kubernetes.csproj: <Version>1.2.0</Version>
+git commit -am "chore: bump service version to 1.2.0"
+git push origin release/service/v1.2.0
 
-# 3. Tag and publish via GitHub Release
-gh release create service/v1.2.0 --target main --generate-notes
+# 3. Open a PR release/service/v1.2.0 -> main and merge it once checks pass.
+#    Merging the PR automatically:
+#      - tags main as service/v1.2.0 (triggers service-release.yml: test, build, push image)
+#      - opens and auto-merges a PR to back-merge release/service/v1.2.0 into develop
+gh pr create --base main --head release/service/v1.2.0 --title "release: service v1.2.0" --fill
+gh pr merge --merge --auto
 
-# 4. Back-merge into develop
-git checkout develop
-git merge --no-ff main
-git push origin develop
-
-# 5. Delete the release branch
+# 4. Once the back-merge PR has merged, delete the release branch
 git push origin --delete release/service/v1.2.0
 git branch -d release/service/v1.2.0
 ```
@@ -98,23 +101,19 @@ If you are releasing a new service version alongside a chart update, update `app
 git checkout develop && git pull origin develop
 git checkout -b release/chart/v1.5.0
 
-# 2. If the chart now targets a new service version, update appVersion
-#    Edit kubernetes/chart/Chart.yaml: appVersion: "1.2.0"
+# 2. Bump the chart version (and appVersion if targeting a new service version)
+#    Edit kubernetes/chart/Chart.yaml: version: "1.5.0" (and appVersion if needed)
+git commit -am "chore: bump chart version to 1.5.0"
+git push origin release/chart/v1.5.0
 
-# 3. Stabilize, then merge into main
-git checkout main && git pull origin main
-git merge --no-ff release/chart/v1.5.0
-git push origin main
+# 3. Open a PR release/chart/v1.5.0 -> main and merge it once checks pass.
+#    Merging the PR automatically:
+#      - tags main as chart/v1.5.0 (triggers chart-release.yml: package, push to GHCR + Pages)
+#      - opens and auto-merges a PR to back-merge release/chart/v1.5.0 into develop
+gh pr create --base main --head release/chart/v1.5.0 --title "release: chart v1.5.0" --fill
+gh pr merge --merge --auto
 
-# 4. Tag and publish via GitHub Release
-gh release create chart/v1.5.0 --target main --generate-notes
-
-# 5. Back-merge into develop
-git checkout develop
-git merge --no-ff main
-git push origin develop
-
-# 6. Delete the release branch
+# 4. Once the back-merge PR has merged, delete the release branch
 git push origin --delete release/chart/v1.5.0
 git branch -d release/chart/v1.5.0
 ```

--- a/kubernetes/service/HmacManager.Kubernetes.csproj
+++ b/kubernetes/service/HmacManager.Kubernetes.csproj
@@ -5,6 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>HmacManager.Kubernetes</RootNamespace>
+    <Version>0.1.0</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- `tag.yml`/`extract-version.sh` predated the split into NuGet/service/chart release pipelines and only ever produced a bare `vX.Y.Z` tag, which matches none of `release.yml` (`nuget/v*`), `service-release.yml` (`service/v*`), or `chart-release.yml` (`chart/v*`). The script now detects the artifact from the release branch name (`release/vX.Y.Z`, `release/service/vX.Y.Z`, `release/chart/vX.Y.Z`) and pushes the correctly-prefixed tag.
- Added an explicit `<Version>` property to `HmacManager.Kubernetes.csproj` (service), matching the existing pattern on `HmacManager.csproj` and `Chart.yaml`.
- `merge-back` job in `tag.yml` now checks for a real diff between the release branch and `develop` before opening the back-merge PR, and fails with an explicit "did you forget to bump the version?" message instead of a confusing `gh pr create` error when there's nothing to merge.
- `RELEASING.md` updated to match: merging into `main` must go through a PR (tag.yml only fires on PR-merge events, not a direct push — the previous doc showed a direct `git merge`/`push` which would never have triggered `tag.yml`), and the now-redundant manual `gh release create <prefix>/vX.Y.Z` step is replaced by the automatic tag-on-merge flow.

## Test plan
- [x] Dry-ran `extract-version.sh` against `release/v2.7.0`, `release/service/v1.2.0`, `release/chart/v1.5.0`, and invalid branch names — confirmed correct prefixed tag output and clear errors.
- [x] Validated `tag.yml` YAML syntax.
- [ ] Exercise a real release branch end-to-end (PR merge → tag → publish workflow → merge-back) once merged, since this can't be fully simulated locally.