### PR TITLE
feat(policies): hot-reload policy config, mount private keys from a Secret volume

### DIFF
--- a/kubernetes/chart/README.md
+++ b/kubernetes/chart/README.md
@@ -119,6 +119,8 @@ policies:
             claimType: userId
 ```
 
+Policy changes — including updating `policies[].privateKeySecret` to point at a rotated key — take effect on running pods without a restart: `helm upgrade` updates the ConfigMap and the projected Secret volume, and each pod picks up the change the next time kubelet syncs its mounted volumes (typically within about a minute). Key rotation is an instant cutover: once a pod reloads, requests signed with the old key are rejected, so coordinate rotation with whoever holds the key.
+
 ### Redis (replay protection)
 
 Redis is deployed as part of this release when `redis.enabled=true` (the default). All policies automatically use the distributed nonce cache. No connection strings, no external Redis cluster required.

--- a/kubernetes/chart/templates/_helpers.tpl
+++ b/kubernetes/chart/templates/_helpers.tpl
@@ -51,8 +51,8 @@ Cluster-internal address of the bundled Redis instance.
 {{/*
 Build the HmacManager policy config JSON from .Values.policies.
 The result is a compact JSON string suitable for use as a ConfigMap value.
-Private keys are intentionally excluded — they are injected at runtime via
-secretKeyRef env vars so they never appear in the ConfigMap.
+Private keys are intentionally excluded — they are mounted at runtime from a
+separate projected Secret volume (see deployment.yaml) so they never appear in the ConfigMap.
 */}}
 {{- define "hmac-manager.policyConfig" -}}
 {{- $root := . -}}

--- a/kubernetes/chart/templates/deployment.yaml
+++ b/kubernetes/chart/templates/deployment.yaml
@@ -24,6 +24,18 @@ spec:
         - name: config
           configMap:
             name: {{ include "hmac-manager.fullname" . }}-config
+        {{- if .Values.policies }}
+        - name: secret-keys
+          projected:
+            sources:
+              {{- range $i, $policy := .Values.policies }}
+              - secret:
+                  name: {{ $policy.privateKeySecret.name }}
+                  items:
+                    - key: {{ $policy.privateKeySecret.key }}
+                      path: {{ printf "HmacManager__%d__Keys__PrivateKey" $i }}
+              {{- end }}
+        {{- end }}
       containers:
         - name: {{ include "hmac-manager.name" . }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -36,6 +48,11 @@ spec:
             - name: config
               mountPath: /etc/hmac-manager
               readOnly: true
+            {{- if .Values.policies }}
+            - name: secret-keys
+              mountPath: /etc/hmac-manager/secrets
+              readOnly: true
+            {{- end }}
           env:
             - name: ASPNETCORE_URLS
               value: "http://+:{{ .Values.service.port }}"
@@ -44,11 +61,4 @@ spec:
             {{- if .Values.redis.enabled }}
             - name: ConnectionStrings__Redis
               value: {{ include "hmac-manager.redisAddress" . | quote }}
-            {{- end }}
-            {{- range $i, $policy := .Values.policies }}
-            - name: HmacManager__{{ $i }}__Keys__PrivateKey
-              valueFrom:
-                secretKeyRef:
-                  name: {{ $policy.privateKeySecret.name }}
-                  key: {{ $policy.privateKeySecret.key }}
             {{- end }}

--- a/kubernetes/chart/tests/deployment_test.yaml
+++ b/kubernetes/chart/tests/deployment_test.yaml
@@ -112,7 +112,7 @@ tests:
           content:
             name: ConnectionStrings__Redis
 
-  - it: injects private key from referenced secret for each policy
+  - it: projects each policy's private key into the secret-keys volume, named for hot-reload binding
     set:
       policies:
         - name: PolicyA
@@ -127,23 +127,23 @@ tests:
             key: key-b
     asserts:
       - contains:
-          path: spec.template.spec.containers[0].env
+          path: spec.template.spec.volumes
           content:
-            name: HmacManager__0__Keys__PrivateKey
-            valueFrom:
-              secretKeyRef:
-                name: secret-a
-                key: key-a
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: HmacManager__1__Keys__PrivateKey
-            valueFrom:
-              secretKeyRef:
-                name: secret-b
-                key: key-b
+            name: secret-keys
+            projected:
+              sources:
+                - secret:
+                    name: secret-a
+                    items:
+                      - key: key-a
+                        path: HmacManager__0__Keys__PrivateKey
+                - secret:
+                    name: secret-b
+                    items:
+                      - key: key-b
+                        path: HmacManager__1__Keys__PrivateKey
 
-  - it: mounts the config ConfigMap as a volume
+  - it: mounts the config ConfigMap and secret-keys volumes read-only
     set:
       policies:
         - name: MyPolicy
@@ -163,6 +163,12 @@ tests:
           content:
             name: config
             mountPath: /etc/hmac-manager
+            readOnly: true
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: secret-keys
+            mountPath: /etc/hmac-manager/secrets
             readOnly: true
 
   - it: allows replicaCount > 1 when redis is enabled

--- a/kubernetes/service/Program.cs
+++ b/kubernetes/service/Program.cs
@@ -5,9 +5,17 @@ var builder = WebApplication.CreateBuilder(args);
 
 // Load the chart-generated policy config mounted at a well-known path.
 // optional: true so the app starts normally outside Kubernetes.
-// Private keys are never written to this file — they arrive via secretKeyRef
-// env vars which cover different config keys, so ordering is not a concern.
-builder.Configuration.AddJsonFile("/etc/hmac-manager/config.json", optional: true, reloadOnChange: false);
+// reloadOnChange: true lets HmacManager pick up edits (e.g. a rotated key) without
+// a pod restart — see HmacPolicyCollectionReloader in the HmacManager library.
+// Private keys are never written to this file — they arrive via a separate mounted
+// Secret volume, read below via AddKeyPerFile, so ordering is not a concern.
+builder.Configuration.AddJsonFile("/etc/hmac-manager/config.json", optional: true, reloadOnChange: true);
+
+// Private keys, one file per policy, named to match the "HmacManager:{i}:Keys:PrivateKey"
+// config path (KeyPerFile's default "__" section delimiter, mirroring the JSON structure
+// above). Mounted from a projected Secret volume so, like config.json, it can be watched
+// and reloaded — see kubernetes/chart/templates/deployment.yaml.
+builder.Configuration.AddKeyPerFile("/etc/hmac-manager/secrets", optional: true, reloadOnChange: true);
 
 // Register a shared distributed cache for nonce storage when a Redis connection
 // string is provided. This must run BEFORE AddHmacManager: the library calls

--- a/src/Mvc/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Mvc/Extensions/IServiceCollectionExtensions.cs
@@ -50,7 +50,7 @@ public static class IServiceCollectionExtensions
         IConfigurationSection configurationSection
     )
     {
-        var policies = configurationSection.GetPolicySection();
+        var policies = new ReloadableHmacPolicyCollection(configurationSection.GetPolicySection());
         _ = new HmacPolicyCollectionReloader(configurationSection, policies);
 
         return services.AddHmacManager(new HmacManagerOptions(policies));

--- a/src/Mvc/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Mvc/Extensions/IServiceCollectionExtensions.cs
@@ -40,12 +40,19 @@ public static class IServiceCollectionExtensions
     /// <param name="services">The <see cref="IServiceCollection"/>.</param>
     /// <param name="configurationSection">The <see cref="IConfigurationSection"/> for an array of JSON objects representing an <see cref="HmacManager.Policies.HmacPolicy"/>.</param>
     /// <returns>An <see cref="IServiceCollection"/> that can be used to further configure services.</returns>
+    /// <remarks>
+    /// If <paramref name="configurationSection"/> supports reload notifications (e.g. it was bound from a
+    /// configuration source added with <c>reloadOnChange: true</c>), the resulting policy collection stays
+    /// in sync with configuration changes for the lifetime of the process — see <see cref="HmacPolicyCollectionReloader"/>.
+    /// </remarks>
     public static IServiceCollection AddHmacManager(
-        this IServiceCollection services, 
+        this IServiceCollection services,
         IConfigurationSection configurationSection
     )
     {
         var policies = configurationSection.GetPolicySection();
+        _ = new HmacPolicyCollectionReloader(configurationSection, policies);
+
         return services.AddHmacManager(new HmacManagerOptions(policies));
     }
 }

--- a/src/Mvc/Extensions/Internal/HmacPolicyCollectionReloader.cs
+++ b/src/Mvc/Extensions/Internal/HmacPolicyCollectionReloader.cs
@@ -1,0 +1,81 @@
+using System.Configuration;
+using System.Text.Json;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Primitives;
+using HmacManager.Policies;
+using HmacManager.Policies.Extensions;
+
+namespace HmacManager.Mvc.Extensions.Internal;
+
+/// <summary>
+/// Watches an <see cref="IConfigurationSection"/> for changes and synchronizes an
+/// <see cref="IHmacPolicyCollection"/> in place, so edits to the underlying configuration
+/// (e.g. a rotated key delivered via a reloadable mounted ConfigMap/Secret) take effect
+/// without restarting the host process.
+/// </summary>
+internal sealed class HmacPolicyCollectionReloader
+{
+    private readonly IConfigurationSection ConfigurationSection;
+    private readonly IHmacPolicyCollection Policies;
+
+    /// <summary>
+    /// Creates an <see cref="HmacPolicyCollectionReloader"/> and immediately subscribes
+    /// to configuration reload notifications for the lifetime of the process.
+    /// </summary>
+    /// <param name="configurationSection">The <see cref="IConfigurationSection"/> policies are bound from.</param>
+    /// <param name="policies">The <see cref="IHmacPolicyCollection"/> to keep in sync, already populated with the initial policy set.</param>
+    public HmacPolicyCollectionReloader(IConfigurationSection configurationSection, IHmacPolicyCollection policies)
+    {
+        ConfigurationSection = configurationSection;
+        Policies = policies;
+
+        ChangeToken.OnChange(ConfigurationSection.GetReloadToken, Reload);
+    }
+
+    /// <summary>
+    /// Rebuilds the policy set from the current configuration and synchronizes it into
+    /// <see cref="Policies"/> in place: policies no longer present are removed, new or
+    /// changed policies are added, and unchanged policies are left untouched.
+    /// </summary>
+    /// <remarks>
+    /// Configuration that fails to bind is ignored and the previous, still-valid policy
+    /// set is left in place until the next change notification. This can happen transiently
+    /// when public policy fields and private keys are delivered via independently-updated
+    /// mounted volumes (ConfigMap vs. Secret), since the two are not guaranteed to update atomically together.
+    /// </remarks>
+    internal void Reload()
+    {
+        HmacPolicyCollection updated;
+        try
+        {
+            updated = ConfigurationSection.GetPolicySection();
+        }
+        catch (ConfigurationErrorsException)
+        {
+            return;
+        }
+
+        var updatedNames = new HashSet<string>(updated.Values.Select(policy => policy.Name!));
+        foreach (var existing in Policies.Values.ToList())
+        {
+            if (!updatedNames.Contains(existing.Name!))
+            {
+                Policies.Remove(existing.Name!);
+            }
+        }
+
+        foreach (var policy in updated.Values)
+        {
+            if (Policies.TryGetValue(policy.Name!, out var current) && AreEqual(current, policy))
+            {
+                continue;
+            }
+
+            Policies.Remove(policy.Name!);
+            Policies.Add(policy);
+        }
+    }
+
+    private static bool AreEqual(HmacPolicy left, HmacPolicy right) =>
+        JsonSerializer.Serialize(left) == JsonSerializer.Serialize(right);
+}

--- a/src/Mvc/Extensions/Internal/HmacPolicyCollectionReloader.cs
+++ b/src/Mvc/Extensions/Internal/HmacPolicyCollectionReloader.cs
@@ -1,47 +1,47 @@
-using System.Configuration;
-using System.Text.Json;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Primitives;
 using HmacManager.Policies;
-using HmacManager.Policies.Extensions;
 
 namespace HmacManager.Mvc.Extensions.Internal;
 
 /// <summary>
-/// Watches an <see cref="IConfigurationSection"/> for changes and synchronizes an
-/// <see cref="IHmacPolicyCollection"/> in place, so edits to the underlying configuration
+/// Watches an <see cref="IConfigurationSection"/> for changes and atomically republishes a
+/// <see cref="ReloadableHmacPolicyCollection"/>, so edits to the underlying configuration
 /// (e.g. a rotated key delivered via a reloadable mounted ConfigMap/Secret) take effect
 /// without restarting the host process.
 /// </summary>
 internal sealed class HmacPolicyCollectionReloader
 {
     private readonly IConfigurationSection ConfigurationSection;
-    private readonly IHmacPolicyCollection Policies;
+    private readonly ReloadableHmacPolicyCollection Collection;
 
     /// <summary>
     /// Creates an <see cref="HmacPolicyCollectionReloader"/> and immediately subscribes
     /// to configuration reload notifications for the lifetime of the process.
     /// </summary>
     /// <param name="configurationSection">The <see cref="IConfigurationSection"/> policies are bound from.</param>
-    /// <param name="policies">The <see cref="IHmacPolicyCollection"/> to keep in sync, already populated with the initial policy set.</param>
-    public HmacPolicyCollectionReloader(IConfigurationSection configurationSection, IHmacPolicyCollection policies)
+    /// <param name="collection">The <see cref="ReloadableHmacPolicyCollection"/> to republish on each change.</param>
+    public HmacPolicyCollectionReloader(IConfigurationSection configurationSection, ReloadableHmacPolicyCollection collection)
     {
         ConfigurationSection = configurationSection;
-        Policies = policies;
+        Collection = collection;
 
         ChangeToken.OnChange(ConfigurationSection.GetReloadToken, Reload);
     }
 
     /// <summary>
-    /// Rebuilds the policy set from the current configuration and synchronizes it into
-    /// <see cref="Policies"/> in place: policies no longer present are removed, new or
-    /// changed policies are added, and unchanged policies are left untouched.
+    /// Rebuilds the policy set from the current configuration and atomically publishes it,
+    /// replacing the previously served set in a single reference swap.
     /// </summary>
     /// <remarks>
-    /// Configuration that fails to bind is ignored and the previous, still-valid policy
-    /// set is left in place until the next change notification. This can happen transiently
-    /// when public policy fields and private keys are delivered via independently-updated
-    /// mounted volumes (ConfigMap vs. Secret), since the two are not guaranteed to update atomically together.
+    /// Configuration that fails to build a valid policy set is ignored and the previous,
+    /// still-valid set is left in place until the next change notification. This happens
+    /// transiently when public policy fields and private keys arrive on independently-updated
+    /// mounted volumes (ConfigMap vs. Secret): a rotation can be observed after config.json
+    /// updates but before the matching private key file syncs, at which point binding throws
+    /// a validation error. Building the new set fully before publishing means a failed reload
+    /// never leaves a partially-updated collection, and swallowing the error here keeps it off
+    /// the configuration reload thread.
     /// </remarks>
     internal void Reload()
     {
@@ -50,32 +50,11 @@ internal sealed class HmacPolicyCollectionReloader
         {
             updated = ConfigurationSection.GetPolicySection();
         }
-        catch (ConfigurationErrorsException)
+        catch (Exception)
         {
             return;
         }
 
-        var updatedNames = new HashSet<string>(updated.Values.Select(policy => policy.Name!));
-        foreach (var existing in Policies.Values.ToList())
-        {
-            if (!updatedNames.Contains(existing.Name!))
-            {
-                Policies.Remove(existing.Name!);
-            }
-        }
-
-        foreach (var policy in updated.Values)
-        {
-            if (Policies.TryGetValue(policy.Name!, out var current) && AreEqual(current, policy))
-            {
-                continue;
-            }
-
-            Policies.Remove(policy.Name!);
-            Policies.Add(policy);
-        }
+        Collection.Replace(updated);
     }
-
-    private static bool AreEqual(HmacPolicy left, HmacPolicy right) =>
-        JsonSerializer.Serialize(left) == JsonSerializer.Serialize(right);
 }

--- a/src/Mvc/Extensions/Internal/ReloadableHmacPolicyCollection.cs
+++ b/src/Mvc/Extensions/Internal/ReloadableHmacPolicyCollection.cs
@@ -1,0 +1,45 @@
+using HmacManager.Common;
+using HmacManager.Policies;
+
+namespace HmacManager.Mvc.Extensions.Internal;
+
+/// <summary>
+/// An <see cref="IHmacPolicyCollection"/> that supports being replaced wholesale by a
+/// configuration reload without disturbing concurrent readers. Reads delegate to an inner
+/// <see cref="HmacPolicyCollection"/> held behind a single <c>volatile</c> reference;
+/// a reload builds a fresh collection and swaps that reference in one atomic assignment.
+/// A reader therefore always observes a complete, immutable snapshot — either the old set
+/// or the new one — never a half-mutated dictionary.
+/// </summary>
+internal sealed class ReloadableHmacPolicyCollection : IHmacPolicyCollection, IComponentCollection<HmacPolicy>
+{
+    private volatile HmacPolicyCollection _current;
+
+    /// <summary>
+    /// Creates a <see cref="ReloadableHmacPolicyCollection"/> around an initial policy set.
+    /// </summary>
+    /// <param name="initial">The initial <see cref="HmacPolicyCollection"/> to serve reads from.</param>
+    public ReloadableHmacPolicyCollection(HmacPolicyCollection initial) => _current = initial;
+
+    /// <summary>
+    /// Atomically replaces the served policy set. Readers in flight complete against the
+    /// previous set; subsequent reads observe <paramref name="next"/>.
+    /// </summary>
+    /// <param name="next">The freshly built <see cref="HmacPolicyCollection"/> to publish.</param>
+    internal void Replace(HmacPolicyCollection next) => _current = next;
+
+    /// <inheritdoc/>
+    public IReadOnlyCollection<HmacPolicy> Values => _current.Values;
+
+    /// <inheritdoc/>
+    public void Add(HmacPolicy policy) => _current.Add(policy);
+
+    /// <inheritdoc/>
+    public void Remove(string policy) => _current.Remove(policy);
+
+    /// <inheritdoc/>
+    public HmacPolicy? Get(string name) => _current.Get(name);
+
+    /// <inheritdoc/>
+    public IReadOnlyCollection<HmacPolicy> GetAll() => _current.GetAll();
+}

--- a/test/Unit/Mvc/Extensions/Internal/Test_HmacPolicyCollectionReloader.cs
+++ b/test/Unit/Mvc/Extensions/Internal/Test_HmacPolicyCollectionReloader.cs
@@ -1,8 +1,9 @@
 using System.Text;
-using HmacManager.Mvc.Extensions.Internal;
+using HmacManager.Mvc.Extensions;
 using HmacManager.Policies;
 using HmacManager.Policies.Extensions;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
 
 namespace Unit.Tests.Mvc.Extensions.Internal;
@@ -10,6 +11,9 @@ namespace Unit.Tests.Mvc.Extensions.Internal;
 [TestFixture]
 public class Test_HmacPolicyCollectionReloader
 {
+    private const string GuidA = "00000000-0000-0000-0000-000000000001";
+    private const string GuidB = "00000000-0000-0000-0000-000000000002";
+
     private string Path = null!;
 
     [SetUp]
@@ -18,27 +22,40 @@ public class Test_HmacPolicyCollectionReloader
     [TearDown]
     public void TearDown() => File.Delete(Path);
 
-    [Test]
-    public void Reload_AddsNewAndReplacesChangedAndRemovesMissingPolicies()
+    /// <summary>
+    /// Registers HmacManager over a file-backed configuration section and returns the
+    /// live policy collection together with the configuration root used to trigger reloads.
+    /// This exercises the same public seam the Kubernetes host uses, so the tests are
+    /// agnostic to how the reloader is wired internally.
+    /// </summary>
+    private (IHmacPolicyCollection Policies, IConfigurationRoot Root) Build(string json)
     {
-        File.WriteAllText(Path, BuildJson(("PolicyA", "00000000-0000-0000-0000-000000000001", "key-a-v1")));
+        File.WriteAllText(Path, json);
 
-        var configurationRoot = new ConfigurationBuilder()
+        var root = new ConfigurationBuilder()
             .AddJsonFile(Path, optional: false, reloadOnChange: false)
             .Build();
 
-        var section = configurationRoot.GetSection("HmacManager");
-        var policies = section.GetPolicySection();
-        _ = new HmacPolicyCollectionReloader(section, policies);
+        var services = new ServiceCollection();
+        services.AddHmacManager(root.GetSection("HmacManager"));
+
+        var provider = services.BuildServiceProvider();
+        return (provider.GetRequiredService<IHmacPolicyCollection>(), root);
+    }
+
+    [Test]
+    public void Reload_AddsNewAndReplacesChangedAndRemovesMissingPolicies()
+    {
+        var (policies, root) = Build(BuildJson((("PolicyA", GuidA, "key-a-v1"))));
 
         Assert.IsTrue(policies.TryGetValue("PolicyA", out var policyA));
         Assert.AreEqual(Encode("key-a-v1"), policyA.Keys.PrivateKey);
 
         // Rotate PolicyA's key and introduce PolicyB.
         File.WriteAllText(Path, BuildJson(
-            ("PolicyA", "00000000-0000-0000-0000-000000000001", "key-a-v2"),
-            ("PolicyB", "00000000-0000-0000-0000-000000000002", "key-b-v1")));
-        configurationRoot.Reload();
+            ("PolicyA", GuidA, "key-a-v2"),
+            ("PolicyB", GuidB, "key-b-v1")));
+        root.Reload();
 
         Assert.IsTrue(policies.TryGetValue("PolicyA", out var rotatedPolicyA));
         Assert.AreEqual(Encode("key-a-v2"), rotatedPolicyA.Keys.PrivateKey);
@@ -47,44 +64,102 @@ public class Test_HmacPolicyCollectionReloader
         CollectionAssert.AreEquivalent(new[] { "PolicyA", "PolicyB" }, policies.Values.Select(p => p.Name));
 
         // Remove PolicyA entirely.
-        File.WriteAllText(Path, BuildJson(("PolicyB", "00000000-0000-0000-0000-000000000002", "key-b-v1")));
-        configurationRoot.Reload();
+        File.WriteAllText(Path, BuildJson(("PolicyB", GuidB, "key-b-v1")));
+        root.Reload();
 
         Assert.IsFalse(policies.TryGetValue("PolicyA", out _));
         CollectionAssert.AreEquivalent(new[] { "PolicyB" }, policies.Values.Select(p => p.Name));
     }
 
     [Test]
-    public void Reload_WithConfigurationThatFailsToBind_LeavesPreviousPoliciesUnchanged()
+    public void Reload_WithEmptySection_LeavesPreviousPoliciesUnchanged()
     {
-        File.WriteAllText(Path, BuildJson(("PolicyA", "00000000-0000-0000-0000-000000000001", "key-a-v1")));
+        var (policies, root) = Build(BuildJson(("PolicyA", GuidA, "key-a-v1")));
 
-        var configurationRoot = new ConfigurationBuilder()
-            .AddJsonFile(Path, optional: false, reloadOnChange: false)
-            .Build();
-
-        var section = configurationRoot.GetSection("HmacManager");
-        var policies = section.GetPolicySection();
-        _ = new HmacPolicyCollectionReloader(section, policies);
-
-        // An empty "HmacManager" section fails to bind any policies.
+        // An empty document binds zero policies.
         File.WriteAllText(Path, "{}");
-        configurationRoot.Reload();
+        Assert.DoesNotThrow(() => root.Reload());
 
         Assert.IsTrue(policies.TryGetValue("PolicyA", out var policyA));
         Assert.AreEqual(Encode("key-a-v1"), policyA.Keys.PrivateKey);
     }
 
+    [Test]
+    public void Reload_WithTransientInvalidPrivateKey_LeavesPreviousPoliciesUnchanged()
+    {
+        var (policies, root) = Build(BuildJson(("PolicyA", GuidA, "key-a-v1")));
+
+        // Simulate a partially-synced rotation: config.json already lists PolicyA, but the
+        // Secret volume hasn't caught up, so the private key is not (yet) valid base64.
+        // Building the policy set throws a validation error that is NOT a ConfigurationErrorsException.
+        File.WriteAllText(Path, BuildJsonRaw(("PolicyA", GuidA, "%%not-base64%%")));
+        Assert.DoesNotThrow(() => root.Reload());
+
+        Assert.IsTrue(policies.TryGetValue("PolicyA", out var policyA));
+        Assert.AreEqual(Encode("key-a-v1"), policyA.Keys.PrivateKey);
+    }
+
+    [Test]
+    public void Reload_UnderConcurrentReads_NeverThrowsAndKeepsPolicyVisible()
+    {
+        var (policies, root) = Build(BuildJson(("PolicyA", GuidA, "key-a-v1")));
+
+        Exception? failure = null;
+        var stop = false;
+
+        var reader = Task.Run(() =>
+        {
+            try
+            {
+                while (!Volatile.Read(ref stop))
+                {
+                    if (!policies.TryGetValue("PolicyA", out _))
+                    {
+                        throw new InvalidOperationException("PolicyA was momentarily missing during a reload.");
+                    }
+
+                    // Materializes a snapshot of the backing store; races with an in-place mutation.
+                    foreach (var _ in policies.Values) { }
+                }
+            }
+            catch (Exception ex)
+            {
+                failure = ex;
+            }
+        });
+
+        try
+        {
+            for (var i = 0; i < 3000 && failure is null; i++)
+            {
+                // Same policy name, alternating key value, so every reload is a replace.
+                var version = i % 2 == 0 ? "key-a-v2" : "key-a-v1";
+                File.WriteAllText(Path, BuildJson(("PolicyA", GuidA, version)));
+                root.Reload();
+            }
+        }
+        finally
+        {
+            Volatile.Write(ref stop, true);
+            reader.Wait();
+        }
+
+        Assert.IsNull(failure, failure?.ToString());
+    }
+
     private static string Encode(string value) => Convert.ToBase64String(Encoding.UTF8.GetBytes(value));
 
-    private static string BuildJson(params (string Name, string PublicKey, string PrivateKey)[] policies)
+    private static string BuildJson(params (string Name, string PublicKey, string PrivateKey)[] policies) =>
+        BuildJsonRaw(policies.Select(p => (p.Name, p.PublicKey, Encode(p.PrivateKey))).ToArray());
+
+    private static string BuildJsonRaw(params (string Name, string PublicKey, string PrivateKey)[] policies)
     {
         var entries = policies.Select(policy => $$"""
             {
                 "Name": "{{policy.Name}}",
                 "Keys": {
                     "PublicKey": "{{policy.PublicKey}}",
-                    "PrivateKey": "{{Encode(policy.PrivateKey)}}"
+                    "PrivateKey": "{{policy.PrivateKey}}"
                 }
             }
             """);

--- a/test/Unit/Mvc/Extensions/Internal/Test_HmacPolicyCollectionReloader.cs
+++ b/test/Unit/Mvc/Extensions/Internal/Test_HmacPolicyCollectionReloader.cs
@@ -1,0 +1,94 @@
+using System.Text;
+using HmacManager.Mvc.Extensions.Internal;
+using HmacManager.Policies;
+using HmacManager.Policies.Extensions;
+using Microsoft.Extensions.Configuration;
+using NUnit.Framework;
+
+namespace Unit.Tests.Mvc.Extensions.Internal;
+
+[TestFixture]
+public class Test_HmacPolicyCollectionReloader
+{
+    private string Path = null!;
+
+    [SetUp]
+    public void SetUp() => Path = System.IO.Path.GetTempFileName();
+
+    [TearDown]
+    public void TearDown() => File.Delete(Path);
+
+    [Test]
+    public void Reload_AddsNewAndReplacesChangedAndRemovesMissingPolicies()
+    {
+        File.WriteAllText(Path, BuildJson(("PolicyA", "00000000-0000-0000-0000-000000000001", "key-a-v1")));
+
+        var configurationRoot = new ConfigurationBuilder()
+            .AddJsonFile(Path, optional: false, reloadOnChange: false)
+            .Build();
+
+        var section = configurationRoot.GetSection("HmacManager");
+        var policies = section.GetPolicySection();
+        _ = new HmacPolicyCollectionReloader(section, policies);
+
+        Assert.IsTrue(policies.TryGetValue("PolicyA", out var policyA));
+        Assert.AreEqual(Encode("key-a-v1"), policyA.Keys.PrivateKey);
+
+        // Rotate PolicyA's key and introduce PolicyB.
+        File.WriteAllText(Path, BuildJson(
+            ("PolicyA", "00000000-0000-0000-0000-000000000001", "key-a-v2"),
+            ("PolicyB", "00000000-0000-0000-0000-000000000002", "key-b-v1")));
+        configurationRoot.Reload();
+
+        Assert.IsTrue(policies.TryGetValue("PolicyA", out var rotatedPolicyA));
+        Assert.AreEqual(Encode("key-a-v2"), rotatedPolicyA.Keys.PrivateKey);
+        Assert.IsTrue(policies.TryGetValue("PolicyB", out var policyB));
+        Assert.AreEqual(Encode("key-b-v1"), policyB.Keys.PrivateKey);
+        CollectionAssert.AreEquivalent(new[] { "PolicyA", "PolicyB" }, policies.Values.Select(p => p.Name));
+
+        // Remove PolicyA entirely.
+        File.WriteAllText(Path, BuildJson(("PolicyB", "00000000-0000-0000-0000-000000000002", "key-b-v1")));
+        configurationRoot.Reload();
+
+        Assert.IsFalse(policies.TryGetValue("PolicyA", out _));
+        CollectionAssert.AreEquivalent(new[] { "PolicyB" }, policies.Values.Select(p => p.Name));
+    }
+
+    [Test]
+    public void Reload_WithConfigurationThatFailsToBind_LeavesPreviousPoliciesUnchanged()
+    {
+        File.WriteAllText(Path, BuildJson(("PolicyA", "00000000-0000-0000-0000-000000000001", "key-a-v1")));
+
+        var configurationRoot = new ConfigurationBuilder()
+            .AddJsonFile(Path, optional: false, reloadOnChange: false)
+            .Build();
+
+        var section = configurationRoot.GetSection("HmacManager");
+        var policies = section.GetPolicySection();
+        _ = new HmacPolicyCollectionReloader(section, policies);
+
+        // An empty "HmacManager" section fails to bind any policies.
+        File.WriteAllText(Path, "{}");
+        configurationRoot.Reload();
+
+        Assert.IsTrue(policies.TryGetValue("PolicyA", out var policyA));
+        Assert.AreEqual(Encode("key-a-v1"), policyA.Keys.PrivateKey);
+    }
+
+    private static string Encode(string value) => Convert.ToBase64String(Encoding.UTF8.GetBytes(value));
+
+    private static string BuildJson(params (string Name, string PublicKey, string PrivateKey)[] policies)
+    {
+        var entries = policies.Select(policy => $$"""
+            {
+                "Name": "{{policy.Name}}",
+                "Keys": {
+                    "PublicKey": "{{policy.PublicKey}}",
+                    "PrivateKey": "{{Encode(policy.PrivateKey)}}"
+                }
+            }
+            """);
+
+        return $$"""{ "HmacManager": [{{string.Join(",", entries)}}] }""";
+    }
+}


### PR DESCRIPTION
## Summary

Stage 1 of the management-portal work (see design discussion): makes policy config and key rotation take effect without a pod restart, which is a prerequisite for a future portal that edits policies live.

- Policies previously loaded once at startup; private keys arrived via `secretKeyRef` env vars, which Kubernetes never refreshes on a running container without a restart.
- `HmacPolicyCollectionReloader` (new, internal) watches an `IConfigurationSection`'s reload token and synchronizes the existing `IHmacPolicyCollection` in place — add/remove/replace by name — tolerating configuration that transiently fails to bind (e.g. a brief window where the ConfigMap and Secret volumes haven't updated together).
- The chart now mounts private keys from a projected Secret volume (`/etc/hmac-manager/secrets`, one file per policy named to match `HmacManager:{i}:Keys:PrivateKey`) instead of env vars.
- `Program.cs` enables `reloadOnChange: true` on both the ConfigMap-backed `config.json` and the new Secret-backed key files via `AddKeyPerFile`.

**Rotation semantics (scoped decision):** rotation is an instant hard cutover — no dual-key/grace-period support. Consumers must pick up a rotated key promptly; mid-flight requests signed with the old key will fail once a pod reloads.

## Test plan
- [x] `dotnet test` in `test/Unit` — 869/869 passing, including new `Test_HmacPolicyCollectionReloader` coverage (add/remove/replace-on-rotation, resilience to transiently invalid config)
- [x] `helm unittest kubernetes/chart` — 42/42 passing, including updated `deployment_test.yaml` assertions for the projected volume/mount
- [x] `helm lint kubernetes/chart`
- [x] `helm template` manually verified rendered volume/mount output for multiple policies