### PR TITLE
fix(ci): trigger releases + auto-merge back via RELEASE_PAT

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -18,6 +18,11 @@ jobs:
         with:
           ref: main
           fetch-depth: 0
+          # Push the tag with a PAT, not GITHUB_TOKEN: tags pushed by the
+          # automatic token are deliberately blocked from triggering other
+          # workflows, so release.yml / *-release.yml never fire. A PAT push
+          # triggers them normally.
+          token: ${{ secrets.RELEASE_PAT }}
 
       - name: Extract tag from branch name
         id: version
@@ -60,7 +65,9 @@ jobs:
 
       - name: Open PR to merge release branch back into develop
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # PAT so `gh pr merge --auto` can enable auto-merge; GITHUB_TOKEN
+          # cannot (fails with "Resource not accessible by integration").
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
         run: |
           PR_URL=$(gh pr create \
             --repo "$GITHUB_REPOSITORY" \


### PR DESCRIPTION
## Problem
`tag.yml` uses the automatic `GITHUB_TOKEN` for two things it can't do:
1. **Push the release tag** — tags pushed with `GITHUB_TOKEN` are deliberately blocked by GitHub from triggering other workflows, so `release.yml` / `*-release.yml` never fire and **nothing publishes**.
2. **`gh pr merge --auto`** on the merge-back PR — `GITHUB_TOKEN` can't enable auto-merge (`Resource not accessible by integration`), so back-merges into `develop` are left unmerged.

Both were hit by the v2.7.0 / operator v0.1.0 / service v0.2.0 release wave (tags pushed, but no publishes; back-merge PRs #61-#63 left open).

## Fix
Push the tag and run the merge-back `gh` commands with a **`RELEASE_PAT`** secret (a user PAT) instead of `GITHUB_TOKEN`.

## Required before this helps
A repo secret **`RELEASE_PAT`** must exist — a PAT with `repo` scope (Contents: write to push tags, Pull requests: write to open/merge the back-merge PR). Create it, then merge this PR. The next release PR merged (the pending **chart v0.2.0**, #60) will exercise it end-to-end.

Note: the already-pushed v2.7.0/operator/service tags still need a one-time manual re-push to publish — this fix is forward-looking.