### PR TITLE
chore: merge release/chart/v0.2.0 back into develop

### DIFF
--- a/kubernetes/chart/Chart.yaml
+++ b/kubernetes/chart/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: hmac-manager
 description: Istio ext-authz HTTP server for HMAC request authentication
 type: application
-version: 0.1.0
-appVersion: "0.1.0"
+version: 0.2.0
+appVersion: "0.2.0"

--- a/kubernetes/chart/values.yaml
+++ b/kubernetes/chart/values.yaml
@@ -3,7 +3,7 @@ fullnameOverride: ""
 
 image:
   repository: zills/hmac-manager
-  tag: 0.1.0
+  tag: 0.2.0
   pullPolicy: IfNotPresent
 
 # The controller that reconciles HmacPolicy resources into the ConfigMap/Secret the


### PR DESCRIPTION
Automated post-release merge. Brings release fixes and merge commits from `release/chart/v0.2.0` back into `develop` to keep branches in sync per gitflow.