### PR TITLE
release: service v0.3.0

### DIFF
--- a/kubernetes/service/HmacManager.Kubernetes.csproj
+++ b/kubernetes/service/HmacManager.Kubernetes.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>HmacManager.Kubernetes</RootNamespace>
-    <Version>0.2.0</Version>
+    <Version>0.3.0</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- **docs: split docker badge into service+operator, document RELEASE_PAT**
- **docs: shorten docker badge labels to service/operator (logo already implies docker)**
- **docs(readme): refresh Features for K8s/operator; add .NET, HmacPolicy CRD, and JS client examples**
- **docs(readme): tone down K8s intro; cover intra-mesh (waypoints), not just edge**
- **docs(readme): mirror .NET layout in client section (npm availability line, npm install, lead-in above snippet)**
- **docs: fix broken client library doc links (stale lib/hmac_manager → lib/src)**
- **chore(deps): bump docker/setup-qemu-action from 3 to 4**
- **chore(deps): bump peter-evans/dockerhub-description from 4 to 5**
- **chore(deps): bump azure/setup-helm from 4 to 5**
- **chore(deps): bump actions/cache from 4 to 6**
- **chore(deps-dev): bump vitest from 4.1.9 to 4.1.10 in /client/lib**
- **chore(deps-dev): bump vite from 8.1.2 to 8.1.3 in /client/lib**
- **chore(deps-dev): bump @types/node from 26.0.1 to 26.1.1 in /client/lib (#73)**
- **chore(deps-dev): bump vite from 8.1.3 to 8.1.4 in /client/lib (#75)**
- **feat(ci): create GitHub Releases from all four release pipelines (#74)**
- **chore(deps-dev): bump vite from 8.1.4 to 8.1.5 in /client/lib (#79)**
- **chore(deps): bump actions/setup-dotnet from 5 to 6 (#78)**
- **chore(deps): bump actions/setup-node from 5 to 7 (#77)**
- **chore(deps-dev): bump @types/node from 26.1.1 to 26.1.2 in /client/lib (#80)**
- **feat: add structured ILogger diagnostics to the library, operator and service (#76)**
- **chore(deps-dev): bump vite from 8.1.5 to 8.2.0 in /client/lib (#81)**
- **chore: bump version to 2.8.0**
- **chore: bump service version to 0.3.0**
