### PR TITLE
chore: merge release/service/v0.3.0 back into develop

### DIFF
--- a/kubernetes/service/HmacManager.Kubernetes.csproj
+++ b/kubernetes/service/HmacManager.Kubernetes.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>HmacManager.Kubernetes</RootNamespace>
-    <Version>0.2.0</Version>
+    <Version>0.3.0</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Automated post-release merge. Brings release fixes and merge commits from `release/service/v0.3.0` back into `develop` to keep branches in sync per gitflow.