### PR TITLE
chore: merge release/operator/v0.2.0 back into develop

### DIFF
--- a/kubernetes/operator/HmacManager.Operator.csproj
+++ b/kubernetes/operator/HmacManager.Operator.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>HmacManager.Operator</RootNamespace>
-    <Version>0.1.0</Version>
+    <Version>0.2.0</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Automated post-release merge. Brings release fixes and merge commits from `release/operator/v0.2.0` back into `develop` to keep branches in sync per gitflow.